### PR TITLE
Bug EU-184

### DIFF
--- a/Frontend/screens/findObjectStack/UploadLostObjectModal.js
+++ b/Frontend/screens/findObjectStack/UploadLostObjectModal.js
@@ -33,7 +33,7 @@ const UploadLostObjectModal = ({ setModalVisible, modalVisible, query, lostDate,
                     username: username,
                     lost_date: lostDate,
                     coordinates: coordinates,
-                    organization_id: organizationId
+                    organization_id: organizationId != null ? String(organizationId) : null
                 },
                 config );
             setResponseOk(true);


### PR DESCRIPTION
BUG - No se puede guardar búsqueda con establecimiento específico

 Contexto y causa raíz

 Al guardar una búsqueda con un establecimiento seleccionado, el frontend envía organization_id como entero JSON (e.g. 5). El backend lo declara como private String organizationId en ReportLostObjectCommand. Spring Boot 3.4.3 usa Jackson 2.17.x que por defecto no coerce enteros JSON a String, lanzando
 MismatchedInputException → respuesta de error → setResponseOk(false) → "No se pudo guardar la búsqueda".

 Cuando se selecciona "No lo recuerdo / No lo sé", organizationId es null → el campo se omite del JSON → Jackson lo deja null sin problema → funciona.


 1. Seleccionar establecimiento específico (UTN FRC, Terminal, etc.) → hacer búsqueda sin resultados → "Guardar búsqueda" → debe mostrar "¡Búsqueda guardada correctamente!".
 2. Seleccionar "No lo recuerdo / No lo sé" → guardar búsqueda → sigue funcionando (no regresión).
 3. Ingresar ubicación manual → guardar → sigue funcionando (no regresión).
