### PR TITLE
Fix EU-184

### DIFF
--- a/Backend/src/main/java/com/eurekapp/backend/repository/LostObjectRepository.java
+++ b/Backend/src/main/java/com/eurekapp/backend/repository/LostObjectRepository.java
@@ -16,6 +16,7 @@ import io.weaviate.client.v1.filters.Operator;
 import org.springframework.stereotype.Component;
 
 import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class LostObjectRepository {
                 .className("LostObject")
                 .properties(Map.of(
                         "username", lostObject.getUsername(),
-                        "lost_date", lostObject.getLostDate().toString()+":00Z",
+                        "lost_date", lostObject.getLostDate().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         "description", lostObject.getDescription(),
                         "organization_id", lostObject.getOrganizationId(),
                         "coordinates", coordinatesMap


### PR DESCRIPTION
Bug — lost_date con formato RFC3339 inválido al guardar búsqueda
  
 Contexto y causa raíz

 Al guardar una búsqueda (POST /lost-objects), Weaviate rechaza el objeto con:
 invalid date property 'lost_date': requires RFC3339, but the given value is '2026-05-25T12:36:53.763:00Z'

 En LostObjectRepository.java línea 68:
 "lost_date", lostObject.getLostDate().toString()+":00Z",
 LocalDateTime.toString() con milisegundos produce 2026-05-25T12:36:53.763. Al concatenar ":00Z" el resultado es 2026-05-25T12:36:53.763:00Z — el :00Z queda insertado en medio del valor decimal, generando una fecha inválida.

 RFC3339 correcto: 2026-05-25T12:36:53.763+00:00 (o ...Z).


 Verificación

 1. Seleccionar cualquier establecimiento → buscar objeto sin coincidencias → "Guardar búsqueda" → debe mostrar "¡Búsqueda guardada correctamente!" sin error 500.
 2. Verificar en Weaviate que el objeto LostObject se creó correctamente con lost_date en formato RFC3339.
